### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.WorldRecord.props
+++ b/props/LiveSplit.WorldRecord.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.WorldRecord.props
+++ b/props/LiveSplit.WorldRecord.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.WorldRecord/LiveSplit.WorldRecord.csproj
+++ b/src/LiveSplit.WorldRecord/LiveSplit.WorldRecord.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="$(LsSrcPath)\UpdateManager\UpdateManager.csproj" Private="false" ExcludeAssets="runtime" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
@@ -395,5 +395,8 @@ public class WorldRecordComponent : IComponent
         Settings.SetSettings(settings);
     }
 
-    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+    public int GetSettingsHashCode()
+    {
+        return Settings.GetSettingsHashCode();
+    }
 }

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
@@ -189,12 +189,13 @@ public class WorldRecordComponent : IComponent
 
             if (centeredText)
             {
-                var textList = new List<string>();
-
-                textList.Add(string.Format("World Record is {0} by {1}", formatted, runners));
-                textList.Add(string.Format("World Record: {0} by {1}", formatted, runners));
-                textList.Add(string.Format("WR: {0} by {1}", formatted, runners));
-                textList.Add(string.Format("WR is {0} by {1}", formatted, runners));
+                var textList = new List<string>
+                {
+                    string.Format("World Record is {0} by {1}", formatted, runners),
+                    string.Format("World Record: {0} by {1}", formatted, runners),
+                    string.Format("WR: {0} by {1}", formatted, runners),
+                    string.Format("WR is {0} by {1}", formatted, runners)
+                };
 
                 if (tieCount > 1)
                 {

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
@@ -180,7 +180,7 @@ public class WorldRecordComponent : IComponent
             var tieCount = AllTies.Count;
 
             var finalTime = GetPBTime(timingMethod);
-            if (IsPBTimeLower(finalTime, time, game != null ? game.Ruleset.ShowMilliseconds : false))
+            if (IsPBTimeLower(finalTime, time, game != null && game.Ruleset.ShowMilliseconds))
             {
                 formatted = LocalTimeFormatter.Format(finalTime);
                 runners = State.Run.Metadata.Category.Players.Value > 1 ? "us" : "me";

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
@@ -106,8 +106,8 @@ public class WorldRecordComponent : IComponent
                     });
                 }
 
-                var regionFilter = Settings.FilterRegion && State.Run.Metadata.Region != null ? State.Run.Metadata.Region.ID : null;
-                var platformFilter = Settings.FilterPlatform && State.Run.Metadata.Platform != null ? State.Run.Metadata.Platform.ID : null;
+                string regionFilter = Settings.FilterRegion && State.Run.Metadata.Region != null ? State.Run.Metadata.Region.ID : null;
+                string platformFilter = Settings.FilterPlatform && State.Run.Metadata.Platform != null ? State.Run.Metadata.Platform.ID : null;
                 EmulatorsFilter emulatorFilter = EmulatorsFilter.NotSet;
                 if (Settings.FilterPlatform)
                 {
@@ -121,9 +121,9 @@ public class WorldRecordComponent : IComponent
                     }
                 }
 
-                var timingMethodFilter = GetTimingMethodOverride();
+                SpeedrunComSharp.TimingMethod? timingMethodFilter = GetTimingMethodOverride();
 
-                var leaderboard = Client.Leaderboards.GetLeaderboardForFullGameCategory(State.Run.Metadata.Game.ID, State.Run.Metadata.Category.ID,
+                Leaderboard leaderboard = Client.Leaderboards.GetLeaderboardForFullGameCategory(State.Run.Metadata.Game.ID, State.Run.Metadata.Category.ID,
                     top: 1,
                     platformId: platformFilter, regionId: regionFilter,
                     emulatorsFilter: emulatorFilter, variableFilters: variableFilter, orderBy: timingMethodFilter);
@@ -146,13 +146,13 @@ public class WorldRecordComponent : IComponent
 
     private void ShowWorldRecord(LayoutMode mode)
     {
-        var centeredText = Settings.CenteredText && !Settings.Display2Rows && mode == LayoutMode.Vertical;
+        bool centeredText = Settings.CenteredText && !Settings.Display2Rows && mode == LayoutMode.Vertical;
         if (WorldRecord != null)
         {
-            var timingMethodOverride = GetTimingMethodOverride();
-            var time = GetWorldRecordTime(timingMethodOverride);
-            var timingMethod = State.CurrentTimingMethod;
-            var game = State.Run.Metadata.Game;
+            SpeedrunComSharp.TimingMethod? timingMethodOverride = GetTimingMethodOverride();
+            TimeSpan? time = GetWorldRecordTime(timingMethodOverride);
+            Model.TimingMethod timingMethod = State.CurrentTimingMethod;
+            Game game = State.Run.Metadata.Game;
             if (game != null)
             {
                 if (timingMethodOverride != null)
@@ -167,19 +167,19 @@ public class WorldRecordComponent : IComponent
                 LocalTimeFormatter.Accuracy = game.Ruleset.ShowMilliseconds ? TimeAccuracy.Milliseconds : TimeAccuracy.Seconds;
             }
 
-            var formatted = TimeFormatter.Format(time);
-            var isLoggedIn = SpeedrunCom.Client.IsAccessTokenValid;
-            var userName = string.Empty;
+            string formatted = TimeFormatter.Format(time);
+            bool isLoggedIn = SpeedrunCom.Client.IsAccessTokenValid;
+            string userName = string.Empty;
             if (isLoggedIn)
             {
                 userName = SpeedrunCom.Client.Profile.Name;
             }
 
-            var runners = string.Join(", ", AllTies.Select(t => string.Join(" & ", t.Players.Select(p =>
+            string runners = string.Join(", ", AllTies.Select(t => string.Join(" & ", t.Players.Select(p =>
                 isLoggedIn && p.Name == userName ? "me" : p.Name))));
-            var tieCount = AllTies.Count;
+            int tieCount = AllTies.Count;
 
-            var finalTime = GetPBTime(timingMethod);
+            TimeSpan? finalTime = GetPBTime(timingMethod);
             if (IsPBTimeLower(finalTime, time, game != null && game.Ruleset.ShowMilliseconds))
             {
                 formatted = LocalTimeFormatter.Format(finalTime);
@@ -263,9 +263,9 @@ public class WorldRecordComponent : IComponent
 
     private TimeSpan? GetPBTime(Model.TimingMethod method)
     {
-        var lastSplit = State.Run.Last();
-        var pbTime = lastSplit.PersonalBestSplitTime[method];
-        var splitTime = lastSplit.SplitTime[method];
+        ISegment lastSplit = State.Run.Last();
+        TimeSpan? pbTime = lastSplit.PersonalBestSplitTime[method];
+        TimeSpan? splitTime = lastSplit.SplitTime[method];
 
         if (State.CurrentPhase == TimerPhase.Ended && splitTime < pbTime)
         {

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
@@ -93,10 +93,14 @@ public class WorldRecordComponent : IComponent
                     variableFilter = State.Run.Metadata.VariableValues.Values.Where(value =>
                     {
                         if (value == null)
+                        {
                             return false;
+                        }
 
                         if (value.Variable.IsSubcategory)
+                        {
                             return Settings.FilterSubcategories;
+                        }
 
                         return Settings.FilterVariables;
                     });
@@ -108,10 +112,15 @@ public class WorldRecordComponent : IComponent
                 if (Settings.FilterPlatform)
                 {
                     if (State.Run.Metadata.UsesEmulator)
+                    {
                         emulatorFilter = EmulatorsFilter.OnlyEmulators;
+                    }
                     else
+                    {
                         emulatorFilter = EmulatorsFilter.NoEmulators;
+                    }
                 }
+
                 var timingMethodFilter = GetTimingMethodOverride();
 
                 var leaderboard = Client.Leaderboards.GetLeaderboardForFullGameCategory(State.Run.Metadata.Game.ID, State.Run.Metadata.Category.ID,
@@ -147,9 +156,13 @@ public class WorldRecordComponent : IComponent
             if (game != null)
             {
                 if (timingMethodOverride != null)
+                {
                     timingMethod = timingMethodOverride.Value.ToLiveSplitTimingMethod();
+                }
                 else
+                {
                     timingMethod = game.Ruleset.DefaultTimingMethod.ToLiveSplitTimingMethod();
+                }
 
                 LocalTimeFormatter.Accuracy = game.Ruleset.ShowMilliseconds ? TimeAccuracy.Milliseconds : TimeAccuracy.Seconds;
             }
@@ -158,7 +171,9 @@ public class WorldRecordComponent : IComponent
             var isLoggedIn = SpeedrunCom.Client.IsAccessTokenValid;
             var userName = string.Empty;
             if (isLoggedIn)
+            {
                 userName = SpeedrunCom.Client.Profile.Name;
+            }
 
             var runners = string.Join(", ", AllTies.Select(t => string.Join(" & ", t.Players.Select(p =>
                 isLoggedIn && p.Name == userName ? "me" : p.Name))));
@@ -233,9 +248,15 @@ public class WorldRecordComponent : IComponent
     private bool IsPBTimeLower(TimeSpan? pbTime, TimeSpan? recordTime, bool showMillis)
     {
         if (pbTime == null || recordTime == null)
+        {
             return false;
+        }
+
         if (showMillis)
+        {
             return (int)pbTime.Value.TotalMilliseconds <= (int)recordTime.Value.TotalMilliseconds;
+        }
+
         return (int)pbTime.Value.TotalSeconds <= (int)recordTime.Value.TotalSeconds;
     }
 
@@ -246,29 +267,50 @@ public class WorldRecordComponent : IComponent
         var splitTime = lastSplit.SplitTime[method];
 
         if (State.CurrentPhase == TimerPhase.Ended && splitTime < pbTime)
+        {
             return splitTime;
+        }
+
         return pbTime;
     }
 
     private TimeSpan? GetWorldRecordTime(SpeedrunComSharp.TimingMethod? timingMethodOverride)
     {
         if (timingMethodOverride == SpeedrunComSharp.TimingMethod.RealTime)
+        {
             return WorldRecord.Times.RealTime;
+        }
+
         if (timingMethodOverride == SpeedrunComSharp.TimingMethod.RealTimeWithoutLoads)
+        {
             return WorldRecord.Times.RealTimeWithoutLoads;
+        }
+
         if (timingMethodOverride == SpeedrunComSharp.TimingMethod.GameTime)
+        {
             return WorldRecord.Times.GameTime;
+        }
+
         return WorldRecord.Times.Primary;
     }
 
     private SpeedrunComSharp.TimingMethod? GetTimingMethodOverride()
     {
         if (Settings.TimingMethod == "Real Time")
+        {
             return SpeedrunComSharp.TimingMethod.RealTime;
+        }
+
         if (Settings.TimingMethod == "Real Time Without Loads")
+        {
             return SpeedrunComSharp.TimingMethod.RealTimeWithoutLoads;
+        }
+
         if (Settings.TimingMethod == "Game Time")
+        {
             return SpeedrunComSharp.TimingMethod.GameTime;
+        }
+
         return null;
     }
 
@@ -314,8 +356,8 @@ public class WorldRecordComponent : IComponent
     private void DrawBackground(Graphics g, LiveSplitState state, float width, float height)
     {
         if (Settings.BackgroundColor.A > 0
-            || Settings.BackgroundGradient != GradientType.Plain
-            && Settings.BackgroundColor2.A > 0)
+            || (Settings.BackgroundGradient != GradientType.Plain
+            && Settings.BackgroundColor2.A > 0))
         {
             var gradientBrush = new LinearGradientBrush(
                         new PointF(0, 0),

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
@@ -1,397 +1,399 @@
-﻿using LiveSplit.Model;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Xml;
+
+using LiveSplit.Model;
+using LiveSplit.Options;
 using LiveSplit.TimeFormatters;
 using LiveSplit.UI;
 using LiveSplit.UI.Components;
 using LiveSplit.Web.Share;
-using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using System.Xml;
+
 using SpeedrunComSharp;
-using System.Collections.ObjectModel;
-using LiveSplit.Options;
 
-namespace LiveSplit.WorldRecord.UI.Components
+namespace LiveSplit.WorldRecord.UI.Components;
+
+public class WorldRecordComponent : IComponent
 {
-    public class WorldRecordComponent : IComponent
+    protected InfoTextComponent InternalComponent { get; set; }
+
+    protected WorldRecordSettings Settings { get; set; }
+
+    private GraphicsCache Cache { get; set; }
+    private ITimeFormatter TimeFormatter { get; set; }
+    private RegularTimeFormatter LocalTimeFormatter { get; set; }
+    private LiveSplitState State { get; set; }
+    private TimeStamp LastUpdate { get; set; }
+    private TimeSpan RefreshInterval { get; set; }
+    public Record WorldRecord { get; protected set; }
+    public ReadOnlyCollection<Record> AllTies { get; protected set; }
+    private bool IsLoading { get; set; }
+    private SpeedrunComClient Client { get; set; }
+
+    public string ComponentName => "World Record";
+
+    public float PaddingTop => InternalComponent.PaddingTop;
+    public float PaddingLeft => InternalComponent.PaddingLeft;
+    public float PaddingBottom => InternalComponent.PaddingBottom;
+    public float PaddingRight => InternalComponent.PaddingRight;
+
+    public float VerticalHeight => InternalComponent.VerticalHeight;
+    public float MinimumWidth => InternalComponent.MinimumWidth;
+    public float HorizontalWidth => InternalComponent.HorizontalWidth;
+    public float MinimumHeight => InternalComponent.MinimumHeight;
+
+    public IDictionary<string, Action> ContextMenuControls => null;
+
+    public WorldRecordComponent(LiveSplitState state)
     {
-        protected InfoTextComponent InternalComponent { get; set; }
+        State = state;
 
-        protected WorldRecordSettings Settings { get; set; }
+        Client = new SpeedrunComClient(userAgent: Updates.UpdateHelper.UserAgent, maxCacheElements: 0);
 
-        private GraphicsCache Cache { get; set; }
-        private ITimeFormatter TimeFormatter { get; set; }
-        private RegularTimeFormatter LocalTimeFormatter { get; set; }
-        private LiveSplitState State { get; set; }
-        private TimeStamp LastUpdate { get; set; }
-        private TimeSpan RefreshInterval { get; set; }
-        public Record WorldRecord { get; protected set; }
-        public ReadOnlyCollection<Record> AllTies { get; protected set; }
-        private bool IsLoading { get; set; }
-        private SpeedrunComClient Client { get; set; }
-
-        public string ComponentName => "World Record";
-
-        public float PaddingTop => InternalComponent.PaddingTop;
-        public float PaddingLeft => InternalComponent.PaddingLeft;
-        public float PaddingBottom => InternalComponent.PaddingBottom;
-        public float PaddingRight => InternalComponent.PaddingRight;
-
-        public float VerticalHeight => InternalComponent.VerticalHeight;
-        public float MinimumWidth => InternalComponent.MinimumWidth;
-        public float HorizontalWidth => InternalComponent.HorizontalWidth;
-        public float MinimumHeight => InternalComponent.MinimumHeight;
-
-        public IDictionary<string, Action> ContextMenuControls => null;
-
-        public WorldRecordComponent(LiveSplitState state)
+        RefreshInterval = TimeSpan.FromMinutes(5);
+        Cache = new GraphicsCache();
+        TimeFormatter = new GeneralTimeFormatter()
         {
-            State = state;
-
-            Client = new SpeedrunComClient(userAgent: Updates.UpdateHelper.UserAgent, maxCacheElements: 0);
-
-            RefreshInterval = TimeSpan.FromMinutes(5);
-            Cache = new GraphicsCache();
-            TimeFormatter = new GeneralTimeFormatter()
-            {
-                NullFormat = NullFormat.ZeroWithAccuracy,
-                DigitsFormat = DigitsFormat.SingleDigitMinutes,
-                Accuracy = TimeAccuracy.Milliseconds,
-            };
-            LocalTimeFormatter = new RegularTimeFormatter();
-            InternalComponent = new InfoTextComponent("World Record", TimeFormatConstants.DASH);
-            Settings = new WorldRecordSettings()
-            {
-                CurrentState = state
-            };
-        }
-
-        public void Dispose()
+            NullFormat = NullFormat.ZeroWithAccuracy,
+            DigitsFormat = DigitsFormat.SingleDigitMinutes,
+            Accuracy = TimeAccuracy.Milliseconds,
+        };
+        LocalTimeFormatter = new RegularTimeFormatter();
+        InternalComponent = new InfoTextComponent("World Record", TimeFormatConstants.DASH);
+        Settings = new WorldRecordSettings()
         {
-        }
+            CurrentState = state
+        };
+    }
 
-        private void RefreshWorldRecord()
+    public void Dispose()
+    {
+    }
+
+    private void RefreshWorldRecord()
+    {
+        LastUpdate = TimeStamp.Now;
+
+        WorldRecord = null;
+
+        try
         {
-            LastUpdate = TimeStamp.Now;
-
-            WorldRecord = null;
-
-            try
+            if (State != null && State.Run != null
+                && State.Run.Metadata.Game != null && State.Run.Metadata.Category != null)
             {
-                if (State != null && State.Run != null
-                    && State.Run.Metadata.Game != null && State.Run.Metadata.Category != null)
+                IEnumerable<VariableValue> variableFilter = null;
+                if (Settings.FilterVariables || Settings.FilterSubcategories)
                 {
-                    IEnumerable<VariableValue> variableFilter = null;
-                    if (Settings.FilterVariables || Settings.FilterSubcategories)
+                    variableFilter = State.Run.Metadata.VariableValues.Values.Where(value =>
                     {
-                        variableFilter = State.Run.Metadata.VariableValues.Values.Where(value => {
-                            if (value == null)
-                                return false;
+                        if (value == null)
+                            return false;
 
-                            if (value.Variable.IsSubcategory)
-                                return Settings.FilterSubcategories;
+                        if (value.Variable.IsSubcategory)
+                            return Settings.FilterSubcategories;
 
-                            return Settings.FilterVariables;
-                        });
-                    }
-
-                    var regionFilter = Settings.FilterRegion && State.Run.Metadata.Region != null ? State.Run.Metadata.Region.ID : null;
-                    var platformFilter = Settings.FilterPlatform && State.Run.Metadata.Platform != null ? State.Run.Metadata.Platform.ID : null;
-                    EmulatorsFilter emulatorFilter = EmulatorsFilter.NotSet;
-                    if (Settings.FilterPlatform)
-                    {
-                        if (State.Run.Metadata.UsesEmulator)
-                            emulatorFilter = EmulatorsFilter.OnlyEmulators;
-                        else
-                            emulatorFilter = EmulatorsFilter.NoEmulators;
-                    }
-                    var timingMethodFilter = GetTimingMethodOverride();
-
-                    var leaderboard = Client.Leaderboards.GetLeaderboardForFullGameCategory(State.Run.Metadata.Game.ID, State.Run.Metadata.Category.ID, 
-                        top: 1,
-                        platformId: platformFilter, regionId: regionFilter, 
-                        emulatorsFilter: emulatorFilter, variableFilters: variableFilter, orderBy: timingMethodFilter);
-
-                    if (leaderboard != null)
-                    {
-                        WorldRecord = leaderboard.Records.FirstOrDefault();
-                        AllTies = leaderboard.Records;
-                    }
+                        return Settings.FilterVariables;
+                    });
                 }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-            }
 
-            IsLoading = false;
-            ShowWorldRecord(State.Layout.Mode);
-        }
-
-        private void ShowWorldRecord(LayoutMode mode)
-        {
-            var centeredText = Settings.CenteredText && !Settings.Display2Rows && mode == LayoutMode.Vertical;
-            if (WorldRecord != null)
-            {
-                var timingMethodOverride = GetTimingMethodOverride();
-                var time = GetWorldRecordTime(timingMethodOverride);
-                var timingMethod = State.CurrentTimingMethod;
-                var game = State.Run.Metadata.Game;
-                if (game != null)
+                var regionFilter = Settings.FilterRegion && State.Run.Metadata.Region != null ? State.Run.Metadata.Region.ID : null;
+                var platformFilter = Settings.FilterPlatform && State.Run.Metadata.Platform != null ? State.Run.Metadata.Platform.ID : null;
+                EmulatorsFilter emulatorFilter = EmulatorsFilter.NotSet;
+                if (Settings.FilterPlatform)
                 {
-                    if (timingMethodOverride != null)
-                        timingMethod = timingMethodOverride.Value.ToLiveSplitTimingMethod();
+                    if (State.Run.Metadata.UsesEmulator)
+                        emulatorFilter = EmulatorsFilter.OnlyEmulators;
                     else
-                        timingMethod = game.Ruleset.DefaultTimingMethod.ToLiveSplitTimingMethod();
-
-                    LocalTimeFormatter.Accuracy = game.Ruleset.ShowMilliseconds ? TimeAccuracy.Milliseconds : TimeAccuracy.Seconds;
+                        emulatorFilter = EmulatorsFilter.NoEmulators;
                 }
+                var timingMethodFilter = GetTimingMethodOverride();
 
-                var formatted = TimeFormatter.Format(time);
-                var isLoggedIn = SpeedrunCom.Client.IsAccessTokenValid;
-                var userName = string.Empty;
-                if (isLoggedIn)
-                    userName = SpeedrunCom.Client.Profile.Name;
+                var leaderboard = Client.Leaderboards.GetLeaderboardForFullGameCategory(State.Run.Metadata.Game.ID, State.Run.Metadata.Category.ID,
+                    top: 1,
+                    platformId: platformFilter, regionId: regionFilter,
+                    emulatorsFilter: emulatorFilter, variableFilters: variableFilter, orderBy: timingMethodFilter);
 
-                var runners = string.Join(", ", AllTies.Select(t => string.Join(" & ", t.Players.Select(p =>
-                    isLoggedIn && p.Name == userName ? "me" : p.Name))));
-                var tieCount = AllTies.Count;
-
-                var finalTime = GetPBTime(timingMethod);
-                if (IsPBTimeLower(finalTime, time, game != null ? game.Ruleset.ShowMilliseconds : false))
+                if (leaderboard != null)
                 {
-                    formatted = LocalTimeFormatter.Format(finalTime);
-                    runners = State.Run.Metadata.Category.Players.Value > 1 ? "us" : "me";
-                    tieCount = 1;
-                }
-
-                if (centeredText)
-                {
-                    var textList = new List<string>();
-
-                    textList.Add(string.Format("World Record is {0} by {1}", formatted, runners));
-                    textList.Add(string.Format("World Record: {0} by {1}", formatted, runners));
-                    textList.Add(string.Format("WR: {0} by {1}", formatted, runners));
-                    textList.Add(string.Format("WR is {0} by {1}", formatted, runners));
-
-                    if (tieCount > 1)
-                    {
-                        textList.Add(string.Format("World Record is {0} ({1}-way tie)", formatted, tieCount));
-                        textList.Add(string.Format("World Record: {0} ({1}-way tie)", formatted, tieCount));
-                        textList.Add(string.Format("WR: {0} ({1}-way tie)", formatted, tieCount));
-                        textList.Add(string.Format("WR is {0} ({1}-way tie)", formatted, tieCount));
-                    }
-
-                    InternalComponent.InformationName = textList.First();
-                    InternalComponent.AlternateNameText = textList;
-                }
-                else
-                {
-                    if (tieCount > 1)
-                    {
-                        InternalComponent.InformationValue = string.Format("{0} ({1}-way tie)", formatted, tieCount);
-                    }
-                    else
-                    {
-                        InternalComponent.InformationValue = string.Format("{0} by {1}", formatted, runners);
-                    }
+                    WorldRecord = leaderboard.Records.FirstOrDefault();
+                    AllTies = leaderboard.Records;
                 }
             }
-            else if (IsLoading)
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+        }
+
+        IsLoading = false;
+        ShowWorldRecord(State.Layout.Mode);
+    }
+
+    private void ShowWorldRecord(LayoutMode mode)
+    {
+        var centeredText = Settings.CenteredText && !Settings.Display2Rows && mode == LayoutMode.Vertical;
+        if (WorldRecord != null)
+        {
+            var timingMethodOverride = GetTimingMethodOverride();
+            var time = GetWorldRecordTime(timingMethodOverride);
+            var timingMethod = State.CurrentTimingMethod;
+            var game = State.Run.Metadata.Game;
+            if (game != null)
             {
-                if (centeredText)
-                {
-                    InternalComponent.InformationName = "Loading World Record...";
-                    InternalComponent.AlternateNameText = new[] { "Loading WR..." };
-                }
+                if (timingMethodOverride != null)
+                    timingMethod = timingMethodOverride.Value.ToLiveSplitTimingMethod();
                 else
+                    timingMethod = game.Ruleset.DefaultTimingMethod.ToLiveSplitTimingMethod();
+
+                LocalTimeFormatter.Accuracy = game.Ruleset.ShowMilliseconds ? TimeAccuracy.Milliseconds : TimeAccuracy.Seconds;
+            }
+
+            var formatted = TimeFormatter.Format(time);
+            var isLoggedIn = SpeedrunCom.Client.IsAccessTokenValid;
+            var userName = string.Empty;
+            if (isLoggedIn)
+                userName = SpeedrunCom.Client.Profile.Name;
+
+            var runners = string.Join(", ", AllTies.Select(t => string.Join(" & ", t.Players.Select(p =>
+                isLoggedIn && p.Name == userName ? "me" : p.Name))));
+            var tieCount = AllTies.Count;
+
+            var finalTime = GetPBTime(timingMethod);
+            if (IsPBTimeLower(finalTime, time, game != null ? game.Ruleset.ShowMilliseconds : false))
+            {
+                formatted = LocalTimeFormatter.Format(finalTime);
+                runners = State.Run.Metadata.Category.Players.Value > 1 ? "us" : "me";
+                tieCount = 1;
+            }
+
+            if (centeredText)
+            {
+                var textList = new List<string>();
+
+                textList.Add(string.Format("World Record is {0} by {1}", formatted, runners));
+                textList.Add(string.Format("World Record: {0} by {1}", formatted, runners));
+                textList.Add(string.Format("WR: {0} by {1}", formatted, runners));
+                textList.Add(string.Format("WR is {0} by {1}", formatted, runners));
+
+                if (tieCount > 1)
                 {
-                    InternalComponent.InformationValue = "Loading...";
+                    textList.Add(string.Format("World Record is {0} ({1}-way tie)", formatted, tieCount));
+                    textList.Add(string.Format("World Record: {0} ({1}-way tie)", formatted, tieCount));
+                    textList.Add(string.Format("WR: {0} ({1}-way tie)", formatted, tieCount));
+                    textList.Add(string.Format("WR is {0} ({1}-way tie)", formatted, tieCount));
                 }
+
+                InternalComponent.InformationName = textList.First();
+                InternalComponent.AlternateNameText = textList;
             }
             else
             {
-                if (centeredText)
+                if (tieCount > 1)
                 {
-                    InternalComponent.InformationName = "Unknown World Record";
-                    InternalComponent.AlternateNameText = new[] { "Unknown WR" };
+                    InternalComponent.InformationValue = string.Format("{0} ({1}-way tie)", formatted, tieCount);
                 }
                 else
                 {
-                    InternalComponent.InformationValue = TimeFormatConstants.DASH;
+                    InternalComponent.InformationValue = string.Format("{0} by {1}", formatted, runners);
                 }
             }
         }
-
-        private bool IsPBTimeLower(TimeSpan? pbTime, TimeSpan? recordTime, bool showMillis)
+        else if (IsLoading)
         {
-            if (pbTime == null || recordTime == null)
-                return false;
-            if (showMillis)
-                return (int)pbTime.Value.TotalMilliseconds <= (int)recordTime.Value.TotalMilliseconds;
-            return (int)pbTime.Value.TotalSeconds <= (int)recordTime.Value.TotalSeconds;
+            if (centeredText)
+            {
+                InternalComponent.InformationName = "Loading World Record...";
+                InternalComponent.AlternateNameText = new[] { "Loading WR..." };
+            }
+            else
+            {
+                InternalComponent.InformationValue = "Loading...";
+            }
         }
-
-        private TimeSpan? GetPBTime(Model.TimingMethod method)
+        else
         {
-            var lastSplit = State.Run.Last();
-            var pbTime = lastSplit.PersonalBestSplitTime[method];
-            var splitTime = lastSplit.SplitTime[method];
-
-            if (State.CurrentPhase == TimerPhase.Ended && splitTime < pbTime)
-                return splitTime;
-            return pbTime;
+            if (centeredText)
+            {
+                InternalComponent.InformationName = "Unknown World Record";
+                InternalComponent.AlternateNameText = new[] { "Unknown WR" };
+            }
+            else
+            {
+                InternalComponent.InformationValue = TimeFormatConstants.DASH;
+            }
         }
+    }
 
-        private TimeSpan? GetWorldRecordTime(SpeedrunComSharp.TimingMethod? timingMethodOverride)
+    private bool IsPBTimeLower(TimeSpan? pbTime, TimeSpan? recordTime, bool showMillis)
+    {
+        if (pbTime == null || recordTime == null)
+            return false;
+        if (showMillis)
+            return (int)pbTime.Value.TotalMilliseconds <= (int)recordTime.Value.TotalMilliseconds;
+        return (int)pbTime.Value.TotalSeconds <= (int)recordTime.Value.TotalSeconds;
+    }
+
+    private TimeSpan? GetPBTime(Model.TimingMethod method)
+    {
+        var lastSplit = State.Run.Last();
+        var pbTime = lastSplit.PersonalBestSplitTime[method];
+        var splitTime = lastSplit.SplitTime[method];
+
+        if (State.CurrentPhase == TimerPhase.Ended && splitTime < pbTime)
+            return splitTime;
+        return pbTime;
+    }
+
+    private TimeSpan? GetWorldRecordTime(SpeedrunComSharp.TimingMethod? timingMethodOverride)
+    {
+        if (timingMethodOverride == SpeedrunComSharp.TimingMethod.RealTime)
+            return WorldRecord.Times.RealTime;
+        if (timingMethodOverride == SpeedrunComSharp.TimingMethod.RealTimeWithoutLoads)
+            return WorldRecord.Times.RealTimeWithoutLoads;
+        if (timingMethodOverride == SpeedrunComSharp.TimingMethod.GameTime)
+            return WorldRecord.Times.GameTime;
+        return WorldRecord.Times.Primary;
+    }
+
+    private SpeedrunComSharp.TimingMethod? GetTimingMethodOverride()
+    {
+        if (Settings.TimingMethod == "Real Time")
+            return SpeedrunComSharp.TimingMethod.RealTime;
+        if (Settings.TimingMethod == "Real Time Without Loads")
+            return SpeedrunComSharp.TimingMethod.RealTimeWithoutLoads;
+        if (Settings.TimingMethod == "Game Time")
+            return SpeedrunComSharp.TimingMethod.GameTime;
+        return null;
+    }
+
+    public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
+    {
+        Cache.Restart();
+        Cache["Game"] = state.Run.GameName;
+        Cache["Category"] = state.Run.CategoryName;
+        Cache["PlatformID"] = Settings.FilterPlatform ? state.Run.Metadata.PlatformName : null;
+        Cache["RegionID"] = Settings.FilterRegion ? state.Run.Metadata.RegionName : null;
+        Cache["UsesEmulator"] = Settings.FilterPlatform ? (bool?)state.Run.Metadata.UsesEmulator : null;
+        Cache["Variables"] = (Settings.FilterVariables || Settings.FilterSubcategories) ? string.Join(",", state.Run.Metadata.VariableValueNames.Values) : null;
+        Cache["FilterVariables"] = Settings.FilterVariables;
+        Cache["FilterSubcategories"] = Settings.FilterSubcategories;
+        Cache["TimingMethod"] = Settings.TimingMethod;
+
+        if (Cache.HasChanged)
         {
-            if (timingMethodOverride == SpeedrunComSharp.TimingMethod.RealTime)
-                return WorldRecord.Times.RealTime;
-            if (timingMethodOverride == SpeedrunComSharp.TimingMethod.RealTimeWithoutLoads)
-                return WorldRecord.Times.RealTimeWithoutLoads;
-            if (timingMethodOverride == SpeedrunComSharp.TimingMethod.GameTime)
-                return WorldRecord.Times.GameTime;
-            return WorldRecord.Times.Primary;
+            IsLoading = true;
+            WorldRecord = null;
+            ShowWorldRecord(mode);
+            Task.Factory.StartNew(RefreshWorldRecord);
         }
-
-        private SpeedrunComSharp.TimingMethod? GetTimingMethodOverride()
+        else if (LastUpdate != null && TimeStamp.Now - LastUpdate >= RefreshInterval)
         {
-            if (Settings.TimingMethod == "Real Time")
-                return SpeedrunComSharp.TimingMethod.RealTime;
-            if (Settings.TimingMethod == "Real Time Without Loads")
-                return SpeedrunComSharp.TimingMethod.RealTimeWithoutLoads;
-            if (Settings.TimingMethod == "Game Time")
-                return SpeedrunComSharp.TimingMethod.GameTime;
-            return null;
+            Task.Factory.StartNew(RefreshWorldRecord);
         }
-
-        public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
+        else
         {
-            Cache.Restart();
-            Cache["Game"] = state.Run.GameName;
-            Cache["Category"] = state.Run.CategoryName;
-            Cache["PlatformID"] = Settings.FilterPlatform ? state.Run.Metadata.PlatformName : null;
-            Cache["RegionID"] = Settings.FilterRegion ? state.Run.Metadata.RegionName : null;
-            Cache["UsesEmulator"] = Settings.FilterPlatform ? (bool?)state.Run.Metadata.UsesEmulator : null;
-            Cache["Variables"] = (Settings.FilterVariables || Settings.FilterSubcategories) ? string.Join(",", state.Run.Metadata.VariableValueNames.Values) : null;
-            Cache["FilterVariables"] = Settings.FilterVariables;
-            Cache["FilterSubcategories"] = Settings.FilterSubcategories;
-            Cache["TimingMethod"] = Settings.TimingMethod;
+            Cache["CenteredText"] = Settings.CenteredText && !Settings.Display2Rows && mode == LayoutMode.Vertical;
+            Cache["RealPBTime"] = GetPBTime(Model.TimingMethod.RealTime);
+            Cache["GamePBTime"] = GetPBTime(Model.TimingMethod.GameTime);
 
             if (Cache.HasChanged)
             {
-                IsLoading = true;
-                WorldRecord = null;
                 ShowWorldRecord(mode);
-                Task.Factory.StartNew(RefreshWorldRecord);
-            }
-            else if (LastUpdate != null && TimeStamp.Now - LastUpdate >= RefreshInterval)
-            {
-                Task.Factory.StartNew(RefreshWorldRecord);
-            }
-            else
-            {
-                Cache["CenteredText"] = Settings.CenteredText && !Settings.Display2Rows && mode == LayoutMode.Vertical;
-                Cache["RealPBTime"] = GetPBTime(Model.TimingMethod.RealTime);
-                Cache["GamePBTime"] = GetPBTime(Model.TimingMethod.GameTime);
-
-                if (Cache.HasChanged)
-                {
-                    ShowWorldRecord(mode);
-                }
-            }
-
-            InternalComponent.Update(invalidator, state, width, height, mode);
-        }
-
-        private void DrawBackground(Graphics g, LiveSplitState state, float width, float height)
-        {
-            if (Settings.BackgroundColor.A > 0
-                || Settings.BackgroundGradient != GradientType.Plain
-                && Settings.BackgroundColor2.A > 0)
-            {
-                var gradientBrush = new LinearGradientBrush(
-                            new PointF(0, 0),
-                            Settings.BackgroundGradient == GradientType.Horizontal
-                            ? new PointF(width, 0)
-                            : new PointF(0, height),
-                            Settings.BackgroundColor,
-                            Settings.BackgroundGradient == GradientType.Plain
-                            ? Settings.BackgroundColor
-                            : Settings.BackgroundColor2);
-                g.FillRectangle(gradientBrush, 0, 0, width, height);
             }
         }
 
-        private void PrepareDraw(LiveSplitState state, LayoutMode mode)
-        {
-            InternalComponent.DisplayTwoRows = Settings.Display2Rows;
-
-            InternalComponent.NameLabel.HasShadow
-                = InternalComponent.ValueLabel.HasShadow
-                = state.LayoutSettings.DropShadows;
-
-            if (Settings.CenteredText && !Settings.Display2Rows && mode == LayoutMode.Vertical)
-            {
-                InternalComponent.NameLabel.HorizontalAlignment = StringAlignment.Center;
-                InternalComponent.ValueLabel.HorizontalAlignment = StringAlignment.Center;
-                InternalComponent.NameLabel.VerticalAlignment = StringAlignment.Center;
-                InternalComponent.ValueLabel.VerticalAlignment = StringAlignment.Center;
-                InternalComponent.InformationValue = "";
-            }
-            else
-            {
-                InternalComponent.InformationName = "World Record";
-                InternalComponent.AlternateNameText = new[]
-                {
-                    "WR"
-                };
-                InternalComponent.NameLabel.HorizontalAlignment = StringAlignment.Near;
-                InternalComponent.ValueLabel.HorizontalAlignment = StringAlignment.Far;
-                InternalComponent.NameLabel.VerticalAlignment =
-                    mode == LayoutMode.Horizontal || Settings.Display2Rows ? StringAlignment.Near : StringAlignment.Center;
-                InternalComponent.ValueLabel.VerticalAlignment =
-                    mode == LayoutMode.Horizontal || Settings.Display2Rows ? StringAlignment.Far : StringAlignment.Center;
-            }
-
-            InternalComponent.NameLabel.ForeColor = Settings.OverrideTextColor ? Settings.TextColor : state.LayoutSettings.TextColor;
-            InternalComponent.ValueLabel.ForeColor = Settings.OverrideTimeColor ? Settings.TimeColor : state.LayoutSettings.TextColor;
-        }
-
-        public void DrawHorizontal(Graphics g, LiveSplitState state, float height, System.Drawing.Region clipRegion)
-        {
-            DrawBackground(g, state, HorizontalWidth, height);
-            PrepareDraw(state, LayoutMode.Horizontal);
-            InternalComponent.DrawHorizontal(g, state, height, clipRegion);
-        }
-
-        public void DrawVertical(Graphics g, LiveSplitState state, float width, System.Drawing.Region clipRegion)
-        {
-            DrawBackground(g, state, width, VerticalHeight);
-            PrepareDraw(state, LayoutMode.Vertical);
-            InternalComponent.DrawVertical(g, state, width, clipRegion);
-        }
-
-        public Control GetSettingsControl(LayoutMode mode)
-        {
-            Settings.Mode = mode;
-            return Settings;
-        }
-
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            return Settings.GetSettings(document);
-        }
-
-        public void SetSettings(XmlNode settings)
-        {
-            Settings.SetSettings(settings);
-        }
-
-        public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+        InternalComponent.Update(invalidator, state, width, height, mode);
     }
+
+    private void DrawBackground(Graphics g, LiveSplitState state, float width, float height)
+    {
+        if (Settings.BackgroundColor.A > 0
+            || Settings.BackgroundGradient != GradientType.Plain
+            && Settings.BackgroundColor2.A > 0)
+        {
+            var gradientBrush = new LinearGradientBrush(
+                        new PointF(0, 0),
+                        Settings.BackgroundGradient == GradientType.Horizontal
+                        ? new PointF(width, 0)
+                        : new PointF(0, height),
+                        Settings.BackgroundColor,
+                        Settings.BackgroundGradient == GradientType.Plain
+                        ? Settings.BackgroundColor
+                        : Settings.BackgroundColor2);
+            g.FillRectangle(gradientBrush, 0, 0, width, height);
+        }
+    }
+
+    private void PrepareDraw(LiveSplitState state, LayoutMode mode)
+    {
+        InternalComponent.DisplayTwoRows = Settings.Display2Rows;
+
+        InternalComponent.NameLabel.HasShadow
+            = InternalComponent.ValueLabel.HasShadow
+            = state.LayoutSettings.DropShadows;
+
+        if (Settings.CenteredText && !Settings.Display2Rows && mode == LayoutMode.Vertical)
+        {
+            InternalComponent.NameLabel.HorizontalAlignment = StringAlignment.Center;
+            InternalComponent.ValueLabel.HorizontalAlignment = StringAlignment.Center;
+            InternalComponent.NameLabel.VerticalAlignment = StringAlignment.Center;
+            InternalComponent.ValueLabel.VerticalAlignment = StringAlignment.Center;
+            InternalComponent.InformationValue = "";
+        }
+        else
+        {
+            InternalComponent.InformationName = "World Record";
+            InternalComponent.AlternateNameText = new[]
+            {
+                "WR"
+            };
+            InternalComponent.NameLabel.HorizontalAlignment = StringAlignment.Near;
+            InternalComponent.ValueLabel.HorizontalAlignment = StringAlignment.Far;
+            InternalComponent.NameLabel.VerticalAlignment =
+                mode == LayoutMode.Horizontal || Settings.Display2Rows ? StringAlignment.Near : StringAlignment.Center;
+            InternalComponent.ValueLabel.VerticalAlignment =
+                mode == LayoutMode.Horizontal || Settings.Display2Rows ? StringAlignment.Far : StringAlignment.Center;
+        }
+
+        InternalComponent.NameLabel.ForeColor = Settings.OverrideTextColor ? Settings.TextColor : state.LayoutSettings.TextColor;
+        InternalComponent.ValueLabel.ForeColor = Settings.OverrideTimeColor ? Settings.TimeColor : state.LayoutSettings.TextColor;
+    }
+
+    public void DrawHorizontal(Graphics g, LiveSplitState state, float height, System.Drawing.Region clipRegion)
+    {
+        DrawBackground(g, state, HorizontalWidth, height);
+        PrepareDraw(state, LayoutMode.Horizontal);
+        InternalComponent.DrawHorizontal(g, state, height, clipRegion);
+    }
+
+    public void DrawVertical(Graphics g, LiveSplitState state, float width, System.Drawing.Region clipRegion)
+    {
+        DrawBackground(g, state, width, VerticalHeight);
+        PrepareDraw(state, LayoutMode.Vertical);
+        InternalComponent.DrawVertical(g, state, width, clipRegion);
+    }
+
+    public Control GetSettingsControl(LayoutMode mode)
+    {
+        Settings.Mode = mode;
+        return Settings;
+    }
+
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        return Settings.GetSettings(document);
+    }
+
+    public void SetSettings(XmlNode settings)
+    {
+        Settings.SetSettings(settings);
+    }
+
+    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
 }

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordFactory.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordFactory.cs
@@ -1,27 +1,27 @@
-﻿using LiveSplit.Model;
+﻿using System;
+
+using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
 
-[assembly:ComponentFactory(typeof(LiveSplit.WorldRecord.UI.Components.WorldRecordFactory))]
+[assembly: ComponentFactory(typeof(LiveSplit.WorldRecord.UI.Components.WorldRecordFactory))]
 
-namespace LiveSplit.WorldRecord.UI.Components
+namespace LiveSplit.WorldRecord.UI.Components;
+
+public class WorldRecordFactory : IComponentFactory
 {
-    public class WorldRecordFactory : IComponentFactory
-    {
-        public string ComponentName => "World Record";
+    public string ComponentName => "World Record";
 
-        public string Description => "Shows the World Record for the run";
+    public string Description => "Shows the World Record for the run";
 
-        public ComponentCategory Category => ComponentCategory.Information;
+    public ComponentCategory Category => ComponentCategory.Information;
 
-        public IComponent Create(LiveSplitState state) => new WorldRecordComponent(state);
+    public IComponent Create(LiveSplitState state) => new WorldRecordComponent(state);
 
-        public string UpdateName => ComponentName;
+    public string UpdateName => ComponentName;
 
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.WorldRecord.xml";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.WorldRecord.xml";
 
-        public string UpdateURL => "http://livesplit.org/update/";
+    public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.8.29");
-    }
+    public Version Version => Version.Parse("1.8.29");
 }

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordFactory.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordFactory.cs
@@ -15,7 +15,10 @@ public class WorldRecordFactory : IComponentFactory
 
     public ComponentCategory Category => ComponentCategory.Information;
 
-    public IComponent Create(LiveSplitState state) => new WorldRecordComponent(state);
+    public IComponent Create(LiveSplitState state)
+    {
+        return new WorldRecordComponent(state);
+    }
 
     public string UpdateName => ComponentName;
 

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
@@ -69,17 +69,17 @@ public partial class WorldRecordSettings : UserControl
         cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
     }
 
-    void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
+    private void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
     {
         label2.Enabled = btnTimeColor.Enabled = chkOverrideTimeColor.Checked;
     }
 
-    void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
+    private void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
     {
         label1.Enabled = btnTextColor.Enabled = chkOverrideTextColor.Checked;
     }
 
-    void WorldRecordSettings_Load(object sender, EventArgs e)
+    private void WorldRecordSettings_Load(object sender, EventArgs e)
     {
         chkOverrideTextColor_CheckedChanged(null, null);
         chkOverrideTimeColor_CheckedChanged(null, null);
@@ -98,7 +98,7 @@ public partial class WorldRecordSettings : UserControl
         chkTwoRows_CheckedChanged(null, null);
     }
 
-    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
     {
         btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
         btnColor2.DataBindings.Clear();

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
@@ -95,6 +95,7 @@ public partial class WorldRecordSettings : UserControl
             chkTwoRows.DataBindings.Clear();
             chkTwoRows.DataBindings.Add("Checked", this, "Display2Rows", false, DataSourceUpdateMode.OnPropertyChanged);
         }
+
         chkTwoRows_CheckedChanged(null, null);
     }
 

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
@@ -2,183 +2,183 @@
 using System.Drawing;
 using System.Windows.Forms;
 using System.Xml;
+
 using LiveSplit.Model;
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public partial class WorldRecordSettings : UserControl
 {
-    public partial class WorldRecordSettings : UserControl
+    public Color TextColor { get; set; }
+    public bool OverrideTextColor { get; set; }
+    public Color TimeColor { get; set; }
+    public bool OverrideTimeColor { get; set; }
+
+    public Color BackgroundColor { get; set; }
+    public Color BackgroundColor2 { get; set; }
+    public GradientType BackgroundGradient { get; set; }
+    public string GradientString
     {
-        public Color TextColor { get; set; }
-        public bool OverrideTextColor { get; set; }
-        public Color TimeColor { get; set; }
-        public bool OverrideTimeColor { get; set; }
+        get { return BackgroundGradient.ToString(); }
+        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+    }
 
-        public Color BackgroundColor { get; set; }
-        public Color BackgroundColor2 { get; set; }
-        public GradientType BackgroundGradient { get; set; }
-        public string GradientString
+    public LiveSplitState CurrentState { get; set; }
+    public bool Display2Rows { get; set; }
+    public bool CenteredText { get; set; }
+
+    public bool FilterVariables { get; set; }
+    public bool FilterPlatform { get; set; }
+    public bool FilterRegion { get; set; }
+    public bool FilterSubcategories { get; set; }
+
+    public string TimingMethod { get; set; }
+
+    public LayoutMode Mode { get; set; }
+
+    public WorldRecordSettings()
+    {
+        InitializeComponent();
+
+        TextColor = Color.FromArgb(255, 255, 255);
+        OverrideTextColor = false;
+        TimeColor = Color.FromArgb(255, 255, 255);
+        OverrideTimeColor = false;
+        BackgroundColor = Color.Transparent;
+        BackgroundColor2 = Color.Transparent;
+        BackgroundGradient = GradientType.Plain;
+        Display2Rows = false;
+        CenteredText = true;
+        FilterVariables = false;
+        FilterPlatform = false;
+        FilterRegion = false;
+        FilterSubcategories = true;
+        TimingMethod = "Default for Leaderboard";
+
+        chkOverrideTextColor.DataBindings.Add("Checked", this, "OverrideTextColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnTextColor.DataBindings.Add("BackColor", this, "TextColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkOverrideTimeColor.DataBindings.Add("Checked", this, "OverrideTimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnTimeColor.DataBindings.Add("BackColor", this, "TimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkRegion.DataBindings.Add("Checked", this, "FilterRegion", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkPlatform.DataBindings.Add("Checked", this, "FilterPlatform", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkVariables.DataBindings.Add("Checked", this, "FilterVariables", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkSubcategories.DataBindings.Add("Checked", this, "FilterSubcategories", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
+    }
+
+    void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
+    {
+        label2.Enabled = btnTimeColor.Enabled = chkOverrideTimeColor.Checked;
+    }
+
+    void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
+    {
+        label1.Enabled = btnTextColor.Enabled = chkOverrideTextColor.Checked;
+    }
+
+    void WorldRecordSettings_Load(object sender, EventArgs e)
+    {
+        chkOverrideTextColor_CheckedChanged(null, null);
+        chkOverrideTimeColor_CheckedChanged(null, null);
+        if (Mode == LayoutMode.Horizontal)
         {
-            get { return BackgroundGradient.ToString(); }
-            set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+            chkTwoRows.Enabled = false;
+            chkTwoRows.DataBindings.Clear();
+            chkTwoRows.Checked = true;
         }
-
-        public LiveSplitState CurrentState { get; set; }
-        public bool Display2Rows { get; set; }
-        public bool CenteredText { get; set; }
-
-        public bool FilterVariables { get; set; }
-        public bool FilterPlatform { get; set; }
-        public bool FilterRegion { get; set; }
-        public bool FilterSubcategories { get; set; }
-
-        public string TimingMethod { get; set; }
-
-        public LayoutMode Mode { get; set; }
-
-        public WorldRecordSettings()
+        else
         {
-            InitializeComponent();
-
-            TextColor = Color.FromArgb(255, 255, 255);
-            OverrideTextColor = false;
-            TimeColor = Color.FromArgb(255, 255, 255);
-            OverrideTimeColor = false;
-            BackgroundColor = Color.Transparent;
-            BackgroundColor2 = Color.Transparent;
-            BackgroundGradient = GradientType.Plain;
-            Display2Rows = false;
-            CenteredText = true;
-            FilterVariables = false;
-            FilterPlatform = false;
-            FilterRegion = false;
-            FilterSubcategories = true;
-            TimingMethod = "Default for Leaderboard";
-
-            chkOverrideTextColor.DataBindings.Add("Checked", this, "OverrideTextColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnTextColor.DataBindings.Add("BackColor", this, "TextColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkOverrideTimeColor.DataBindings.Add("Checked", this, "OverrideTimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnTimeColor.DataBindings.Add("BackColor", this, "TimeColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkRegion.DataBindings.Add("Checked", this, "FilterRegion", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkPlatform.DataBindings.Add("Checked", this, "FilterPlatform", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkVariables.DataBindings.Add("Checked", this, "FilterVariables", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkSubcategories.DataBindings.Add("Checked", this, "FilterSubcategories", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
+            chkTwoRows.Enabled = true;
+            chkTwoRows.DataBindings.Clear();
+            chkTwoRows.DataBindings.Add("Checked", this, "Display2Rows", false, DataSourceUpdateMode.OnPropertyChanged);
         }
+        chkTwoRows_CheckedChanged(null, null);
+    }
 
-        void chkOverrideTimeColor_CheckedChanged(object sender, EventArgs e)
+    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
+        btnColor2.DataBindings.Clear();
+        btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        GradientString = cmbGradientType.SelectedItem.ToString();
+    }
+
+    public void SetSettings(XmlNode node)
+    {
+        var element = (XmlElement)node;
+        TextColor = SettingsHelper.ParseColor(element["TextColor"]);
+        OverrideTextColor = SettingsHelper.ParseBool(element["OverrideTextColor"]);
+        TimeColor = SettingsHelper.ParseColor(element["TimeColor"]);
+        OverrideTimeColor = SettingsHelper.ParseBool(element["OverrideTimeColor"]);
+        BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"]);
+        BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"]);
+        GradientString = SettingsHelper.ParseString(element["BackgroundGradient"]);
+        Display2Rows = SettingsHelper.ParseBool(element["Display2Rows"]);
+        CenteredText = SettingsHelper.ParseBool(element["CenteredText"]);
+        FilterRegion = SettingsHelper.ParseBool(element["FilterRegion"]);
+        FilterPlatform = SettingsHelper.ParseBool(element["FilterPlatform"]);
+        FilterVariables = SettingsHelper.ParseBool(element["FilterVariables"]);
+        FilterSubcategories = SettingsHelper.ParseBool(element["FilterSubcategories"], true);
+        TimingMethod = SettingsHelper.ParseString(element["TimingMethod"], "Default for Leaderboard");
+    }
+
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        var parent = document.CreateElement("Settings");
+        CreateSettingsNode(document, parent);
+        return parent;
+    }
+
+    public int GetSettingsHashCode()
+    {
+        return CreateSettingsNode(null, null);
+    }
+
+    private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+    {
+        return SettingsHelper.CreateSetting(document, parent, "Version", "1.6") ^
+        SettingsHelper.CreateSetting(document, parent, "TextColor", TextColor) ^
+        SettingsHelper.CreateSetting(document, parent, "OverrideTextColor", OverrideTextColor) ^
+        SettingsHelper.CreateSetting(document, parent, "TimeColor", TimeColor) ^
+        SettingsHelper.CreateSetting(document, parent, "OverrideTimeColor", OverrideTimeColor) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
+        SettingsHelper.CreateSetting(document, parent, "Display2Rows", Display2Rows) ^
+        SettingsHelper.CreateSetting(document, parent, "CenteredText", CenteredText) ^
+        SettingsHelper.CreateSetting(document, parent, "FilterRegion", FilterRegion) ^
+        SettingsHelper.CreateSetting(document, parent, "FilterPlatform", FilterPlatform) ^
+        SettingsHelper.CreateSetting(document, parent, "FilterVariables", FilterVariables) ^
+        SettingsHelper.CreateSetting(document, parent, "FilterSubcategories", FilterSubcategories) ^
+        SettingsHelper.CreateSetting(document, parent, "TimingMethod", TimingMethod);
+    }
+
+    private void ColorButtonClick(object sender, EventArgs e)
+    {
+        SettingsHelper.ColorButtonClick((Button)sender, this);
+    }
+
+    private void chkTwoRows_CheckedChanged(object sender, EventArgs e)
+    {
+        if (chkTwoRows.Checked)
         {
-            label2.Enabled = btnTimeColor.Enabled = chkOverrideTimeColor.Checked;
+            chkCenteredText.Enabled = false;
+            chkCenteredText.DataBindings.Clear();
+            chkCenteredText.Checked = false;
         }
-
-        void chkOverrideTextColor_CheckedChanged(object sender, EventArgs e)
+        else
         {
-            label1.Enabled = btnTextColor.Enabled = chkOverrideTextColor.Checked;
+            chkCenteredText.Enabled = true;
+            chkCenteredText.DataBindings.Clear();
+            chkCenteredText.DataBindings.Add("Checked", this, "CenteredText", false, DataSourceUpdateMode.OnPropertyChanged);
         }
+    }
 
-        void WorldRecordSettings_Load(object sender, EventArgs e)
-        {
-            chkOverrideTextColor_CheckedChanged(null, null);
-            chkOverrideTimeColor_CheckedChanged(null, null);
-            if (Mode == LayoutMode.Horizontal)
-            {
-                chkTwoRows.Enabled = false;
-                chkTwoRows.DataBindings.Clear();
-                chkTwoRows.Checked = true;
-            }
-            else
-            {
-                chkTwoRows.Enabled = true;
-                chkTwoRows.DataBindings.Clear();
-                chkTwoRows.DataBindings.Add("Checked", this, "Display2Rows", false, DataSourceUpdateMode.OnPropertyChanged);
-            }
-            chkTwoRows_CheckedChanged(null, null);
-        }
-
-        void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
-            btnColor2.DataBindings.Clear();
-            btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            GradientString = cmbGradientType.SelectedItem.ToString();
-        }
-
-        public void SetSettings(XmlNode node)
-        {
-            var element = (XmlElement)node;
-            TextColor = SettingsHelper.ParseColor(element["TextColor"]);
-            OverrideTextColor = SettingsHelper.ParseBool(element["OverrideTextColor"]);
-            TimeColor = SettingsHelper.ParseColor(element["TimeColor"]);
-            OverrideTimeColor = SettingsHelper.ParseBool(element["OverrideTimeColor"]);
-            BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"]);
-            BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"]);
-            GradientString = SettingsHelper.ParseString(element["BackgroundGradient"]);
-            Display2Rows = SettingsHelper.ParseBool(element["Display2Rows"]);
-            CenteredText = SettingsHelper.ParseBool(element["CenteredText"]);
-            FilterRegion = SettingsHelper.ParseBool(element["FilterRegion"]);
-            FilterPlatform = SettingsHelper.ParseBool(element["FilterPlatform"]);
-            FilterVariables = SettingsHelper.ParseBool(element["FilterVariables"]);
-            FilterSubcategories = SettingsHelper.ParseBool(element["FilterSubcategories"], true);
-            TimingMethod = SettingsHelper.ParseString(element["TimingMethod"], "Default for Leaderboard");
-        }
-
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            var parent = document.CreateElement("Settings");
-            CreateSettingsNode(document, parent);
-            return parent;
-        }
-
-        public int GetSettingsHashCode()
-        {
-            return CreateSettingsNode(null, null);
-        }
-
-        private int CreateSettingsNode(XmlDocument document, XmlElement parent)
-        {
-            return SettingsHelper.CreateSetting(document, parent, "Version", "1.6") ^
-            SettingsHelper.CreateSetting(document, parent, "TextColor", TextColor) ^
-            SettingsHelper.CreateSetting(document, parent, "OverrideTextColor", OverrideTextColor) ^
-            SettingsHelper.CreateSetting(document, parent, "TimeColor", TimeColor) ^
-            SettingsHelper.CreateSetting(document, parent, "OverrideTimeColor", OverrideTimeColor) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
-            SettingsHelper.CreateSetting(document, parent, "Display2Rows", Display2Rows) ^
-            SettingsHelper.CreateSetting(document, parent, "CenteredText", CenteredText) ^
-            SettingsHelper.CreateSetting(document, parent, "FilterRegion", FilterRegion) ^
-            SettingsHelper.CreateSetting(document, parent, "FilterPlatform", FilterPlatform) ^
-            SettingsHelper.CreateSetting(document, parent, "FilterVariables", FilterVariables) ^
-            SettingsHelper.CreateSetting(document, parent, "FilterSubcategories", FilterSubcategories) ^
-            SettingsHelper.CreateSetting(document, parent, "TimingMethod", TimingMethod);
-        }
-
-        private void ColorButtonClick(object sender, EventArgs e)
-        {
-            SettingsHelper.ColorButtonClick((Button)sender, this);
-        }
-
-        private void chkTwoRows_CheckedChanged(object sender, EventArgs e)
-        {
-            if (chkTwoRows.Checked)
-            {
-                chkCenteredText.Enabled = false;
-                chkCenteredText.DataBindings.Clear();
-                chkCenteredText.Checked = false;
-            }
-            else
-            {
-                chkCenteredText.Enabled = true;
-                chkCenteredText.DataBindings.Clear();
-                chkCenteredText.DataBindings.Add("Checked", this, "CenteredText", false, DataSourceUpdateMode.OnPropertyChanged);
-            }
-        }
-
-        private void cmbTimingMethod_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            TimingMethod = cmbTimingMethod.SelectedItem.ToString();
-        }
+    private void cmbTimingMethod_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        TimingMethod = cmbTimingMethod.SelectedItem.ToString();
     }
 }

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
@@ -128,7 +128,7 @@ public partial class WorldRecordSettings : UserControl
 
     public XmlNode GetSettings(XmlDocument document)
     {
-        var parent = document.CreateElement("Settings");
+        XmlElement parent = document.CreateElement("Settings");
         CreateSettingsNode(document, parent);
         return parent;
     }

--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordSettings.cs
@@ -19,8 +19,8 @@ public partial class WorldRecordSettings : UserControl
     public GradientType BackgroundGradient { get; set; }
     public string GradientString
     {
-        get { return BackgroundGradient.ToString(); }
-        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+        get => BackgroundGradient.ToString();
+        set => BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value);
     }
 
     public LiveSplitState CurrentState { get; set; }


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
