### PR TITLE
Add GlobalFontConsumer attribute for per-component font override support

### DIFF
--- a/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
+++ b/src/LiveSplit.WorldRecord/UI/Components/WorldRecordComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Drawing;
@@ -20,6 +20,7 @@ using SpeedrunComSharp;
 
 namespace LiveSplit.WorldRecord.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TextFont)]
 public class WorldRecordComponent : IComponent
 {
     private static string T(string source) => UiLocalizer.Translate(source, LanguageResolver.ResolveCurrentCultureLanguage());


### PR DESCRIPTION
## Summary
- Add `[GlobalFontConsumer]` attribute to declare which global fonts the component uses
- Enables the per-component font override system introduced in LiveSplit/LiveSplit#2688